### PR TITLE
cppresksdk :: TONE-4193 :: mechanism to inspect json during token retrieval

### DIFF
--- a/Release/src/http/oauth/oauth2.cpp
+++ b/Release/src/http/oauth/oauth2.cpp
@@ -143,7 +143,7 @@ pplx::task<void> oauth2_config::_request_token(uri_builder& request_body_ub, ins
     return token_client.request(request)
         .then([](http_response resp) { return resp.extract_json(); })
         .then([this,inspect_func = std::move(inspect_func)](json::value json_resp) -> void {
-            inspect_func( json_resp );
+            inspect_func(json_resp);
             set_token(_parse_token_from_json(json_resp));
         });
 }


### PR DESCRIPTION
# What
add a function that can look at the JSON during the token fetching process

# Why
Fender API's use the `id_token` instead of `access_token` which is non-standard, and not supported by casablanca